### PR TITLE
Orientation, indexing and tiff support fixes

### DIFF
--- a/bq3d/alignment/resampling.py
+++ b/bq3d/alignment/resampling.py
@@ -58,7 +58,10 @@ def invert_orientation(orientation: tuple):
     """
 
     if orientation:
-        return tuple(ax * -1 for ax in orientation)
+        signs = numpy.sign(orientation)
+        inv = numpy.array(orientation)
+        inv[abs(inv)-1] = signs * numpy.array(range(1,1+len(orientation)))
+        return tuple(inv)
 
     return None
 

--- a/bq3d/analysis/label_properties.py
+++ b/bq3d/analysis/label_properties.py
@@ -87,7 +87,7 @@ def region_props(label_image, intensity_image=None):
         props = RegionProperties(sl, label, label_image, intensity_image)
         regions.append(props)
 
-    log.info(f'Objects Detected: {len(props)} in {len(objects)} label IDs.')
+    log.info(f'Objects Detected: {len(regions)} in {len(objects)} label IDs.')
 
     return regions
 

--- a/bq3d/analysis/label_properties.py
+++ b/bq3d/analysis/label_properties.py
@@ -77,7 +77,6 @@ def region_props(label_image, intensity_image=None):
 
     regions = []
     objects = ndi.find_objects(label_image)
-    log.info(f'Objects Detected: {len(objects)}')
 
     for i, sl in enumerate(objects):
         if sl is None:
@@ -87,6 +86,8 @@ def region_props(label_image, intensity_image=None):
 
         props = RegionProperties(sl, label, label_image, intensity_image)
         regions.append(props)
+
+    log.info(f'Objects Detected: {len(props)} in {len(objects)} label IDs.')
 
     return regions
 

--- a/bq3d/image_filters/filters/label/label.py
+++ b/bq3d/image_filters/filters/label/label.py
@@ -27,7 +27,7 @@ __status__     = "Development"
 
 
 class Label(FilterBase):
-    """thresholds image using Ilastik's threshold applet
+    """thresholds image
 
     Attributes:
          input          (array): Image to pass through filter, munt be memmapped.
@@ -41,9 +41,9 @@ class Label(FilterBase):
          low_threshold  (float): Probability threshold for optional second filtering.
          mode           (int): Options are:
                                 1 : High Threshold --> Label --> Size Filter
-                                3 : Mode 1 --> Low Thresh --> Label -->
+                                2 : Mode 1 --> Low Thresh --> Label -->
                                       Compare with size filtered and keep overlap --> Size Filter (2nd Pass)
-                                2 : Mode 1 --> Low Thresh --> Watershed --> Size Filter (2nd Pass)
+                                3 : Mode 1 --> Low Thresh --> Watershed --> Size Filter (2nd Pass)
     """
 
     def __init__(self):

--- a/bq3d/io/FileList.py
+++ b/bq3d/io/FileList.py
@@ -169,11 +169,11 @@ def readDataFiles(filename, x = None, y = None, z = None, **args):
     fn = os.path.join(fpath, fl[rz[0]])
     img = io.readData(fn, x = x, y = y, returnMemmap = False)
     nxy = img.shape
-    data = numpy.zeros(nxy + (sz,), dtype = img.dtype)
+    data = numpy.zeros((sz,) + nxy, dtype = img.dtype)
     data[0,:,:] = img
 
     for i in range(rz[0]+1, rz[1]):
-        log.info("CAUTION: UNTESTED CODE. Double check the validity of your result if you run into this part the code.")
+        log.info("CAUTION: UNTESTED CODE. Double check the validity of your result if you run into this part of the code.")
         fn = os.path.join(fpath, fl[i])
         data[i-rz[0],:,:] = io.readData(fn, x = x, y = y, returnMemmap = False)
 

--- a/bq3d/io/FileList.py
+++ b/bq3d/io/FileList.py
@@ -145,7 +145,7 @@ def getDataType(filename):
     Returns:
         dtype: data type
     """
-    return io.readData(filename, z=0).dtype
+    return io.readData(filename, z=0, returnMemmap=False).dtype  #Tif.readData(returnMemmap)
 
 
 def readDataFiles(filename, x = None, y = None, z = None, **args):
@@ -167,14 +167,14 @@ def readDataFiles(filename, x = None, y = None, z = None, **args):
     rz = io.toDataRange(nz, r = z)
     sz = io.toDataSize(nz, r = z)
     fn = os.path.join(fpath, fl[rz[0]])
-    img = io.readData(fn, x = x, y = y)
+    img = io.readData(fn, x = x, y = y, returnMemmap = False)
     nxy = img.shape
     data = numpy.zeros(nxy + (sz,), dtype = img.dtype)
     data[:,:,0] = img
 
     for i in range(rz[0]+1, rz[1]):
         fn = os.path.join(fpath, fl[i])
-        data[:,:,i-rz[0]] = io.readData(fn, x = x, y = y)
+        data[:,:,i-rz[0]] = io.readData(fn, x = x, y = y, returnMemmap = False)
 
     return data
 

--- a/bq3d/io/FileList.py
+++ b/bq3d/io/FileList.py
@@ -170,16 +170,12 @@ def readDataFiles(filename, x = None, y = None, z = None, **args):
     img = io.readData(fn, x = x, y = y, returnMemmap = False)
     nxy = img.shape
     data = numpy.zeros(nxy + (sz,), dtype = img.dtype)
-
-    print('SHANG------data.shape', data.shape)
-
-    data[:,:,0] = img
+    data[0,:,:] = img
 
     for i in range(rz[0]+1, rz[1]):
-        print(r'SHANG------+++++++++++++++++++++++++*****************************HUGE BUG ACTUALLY USED??')
-        raise RuntimeError
+        log.info("CAUTION: UNTESTED CODE. Double check the validity of your result if you run into this part the code.")
         fn = os.path.join(fpath, fl[i])
-        data[:,:,i-rz[0]] = io.readData(fn, x = x, y = y, returnMemmap = False)
+        data[i-rz[0],:,:] = io.readData(fn, x = x, y = y, returnMemmap = False)
 
     return data
 

--- a/bq3d/io/FileList.py
+++ b/bq3d/io/FileList.py
@@ -173,7 +173,7 @@ def readDataFiles(filename, x = None, y = None, z = None, **args):
     data[0,:,:] = img
 
     for i in range(rz[0]+1, rz[1]):
-        log.info("CAUTION: UNTESTED CODE. Double check the validity of your result if you run into this part of the code.")
+        log.info(f"CAUTION: UNTESTED CODE. Double check validity of your result if you run into this part of the code. - {__file__}")
         fn = os.path.join(fpath, fl[i])
         data[i-rz[0],:,:] = io.readData(fn, x = x, y = y, returnMemmap = False)
 

--- a/bq3d/io/FileList.py
+++ b/bq3d/io/FileList.py
@@ -247,7 +247,9 @@ def writeData(filename, data, startIndex = 0, rgb = False, substack = None, **kw
         else:
             for i in range(nz):
                 fname = fileheader + (digitfrmt % (i + startIndex)) + fileext
+                log.verbose(f'writing to {fname} at {substack}')
                 io.writeData(fname, data[i], substack=substack)
+                log.verbose(f'done writing to {fname} at {substack}')
             return filename
 
 

--- a/bq3d/io/FileList.py
+++ b/bq3d/io/FileList.py
@@ -170,9 +170,14 @@ def readDataFiles(filename, x = None, y = None, z = None, **args):
     img = io.readData(fn, x = x, y = y, returnMemmap = False)
     nxy = img.shape
     data = numpy.zeros(nxy + (sz,), dtype = img.dtype)
+
+    print('SHANG------data.shape', data.shape)
+
     data[:,:,0] = img
 
     for i in range(rz[0]+1, rz[1]):
+        print(r'SHANG------+++++++++++++++++++++++++*****************************HUGE BUG ACTUALLY USED??')
+        raise RuntimeError
         fn = os.path.join(fpath, fl[i])
         data[:,:,i-rz[0]] = io.readData(fn, x = x, y = y, returnMemmap = False)
 

--- a/bq3d/io/TIF.py
+++ b/bq3d/io/TIF.py
@@ -22,15 +22,19 @@ def dataSize(filename, **args):
     """Returns size of data in tif file
     
     Arguments:
-        filename (str): file name as regular expression
+        filename (str): file name
         x,y,z (tuple): data range specifications
     
     Returns:
         tuple: data size
     """
 
-    t = tif.tifffile.memmap(filename)
-    s = t.shape
+    try:
+        t = tif.tifffile.memmap(filename)
+        s = t.shape
+    except ValueError:      # not memmap'able
+        data = tif.imread(filename)
+        s = data.shape
 
     return io.dataSizeFromDataRange(s, **args)
 
@@ -74,7 +78,7 @@ def readData(filename, x = None, y = None, z = None, returnMemmap = True, **kwar
     """Read data from a single tif image or stack
     
     Arguments:
-        filename (str): file name as regular expression
+        filename (str): file name
         x,y,z (tuple): data range specifications
     
     Returns:
@@ -91,7 +95,7 @@ def readData(filename, x = None, y = None, z = None, returnMemmap = True, **kwar
 
 def empty(filename, shape, dtype, **kwargs):
 
-    return tif.tifffile.memmap(filename, shape=shape, dtype=dtype, **kwargs)
+    return tif.tifffile.memmap(filename, shape=shape, dtype=dtype, byteorder=None, **kwargs)    # only native byteorder datatype is memmap'able
 
 
 def writeData(filename, data, rgb = False, substack = None, returnMemmap = True):

--- a/bq3d/io/TIF.py
+++ b/bq3d/io/TIF.py
@@ -138,6 +138,8 @@ def writeData(filename, data, rgb = False, substack = None, returnMemmap = True)
                 raise RuntimeError('writing {} dimensional data to tif not supported!'.format(len(data.shape)))
 
         data_map[:] = data
+
+        del data_map  # properly close the file. can otherwise get error on accessing the new file after renaming on the next line
         shutil.move(fn, filename)
 
     if returnMemmap:

--- a/bq3d/stack_processing/cell_detection.py
+++ b/bq3d/stack_processing/cell_detection.py
@@ -117,7 +117,7 @@ def process_flow(source,
             results = pool.starmap(processSubStack, argdata)
             pool.close()
     except Exception as err:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        #shutil.rmtree(temp_dir, ignore_errors=True)
         raise err
 
     # join results
@@ -125,7 +125,7 @@ def process_flow(source,
         results = join_points(results, unique_chunks, overlap_chunks)
         results = jsonify_points(output_properties, results)
 
-    shutil.rmtree(temp_dir, ignore_errors=True)
+    #shutil.rmtree(temp_dir, ignore_errors=True)
     if sink:
         io.writePoints(sink, results)
 

--- a/bq3d/stack_processing/cell_detection.py
+++ b/bq3d/stack_processing/cell_detection.py
@@ -125,9 +125,10 @@ def process_flow(source,
         results = join_points(results, unique_chunks, overlap_chunks)
         results = jsonify_points(output_properties, results)
 
-    #shutil.rmtree(temp_dir, ignore_errors=True)
     if sink:
         io.writePoints(sink, results)
+
+    shutil.rmtree(temp_dir, ignore_errors=True)
 
     return results
 

--- a/bq3d/stack_processing/parallelization.py
+++ b/bq3d/stack_processing/parallelization.py
@@ -75,7 +75,7 @@ def processSubStack(flow, output_properties, source, overlap_indices, unique_ind
 
         # save intermediate output
         if save:
-            log.info(f'Saving output to {save}')
+            log.info(f'Saving output to {save} at {unique_indices} from {overlap_indices}')
             h, ext, dfmt = splitFileExpression(save)
 
             for z in range(*zRng):
@@ -85,6 +85,7 @@ def processSubStack(flow, output_properties, source, overlap_indices, unique_ind
 
             unique = filtered_im[unique_slice(overlap_indices, unique_indices)]
             io.writeData(save, unique, substack=unique_indices)
+            log.verbose(f'Done Saving output to {save} at {unique_indices}')
 
     # get label properties and return
     if output_properties:

--- a/bq3d/stack_processing/parallelization.py
+++ b/bq3d/stack_processing/parallelization.py
@@ -5,6 +5,7 @@ from bq3d.utils.timer import Timer
 from bq3d import io
 from bq3d.io.FileList import splitFileExpression
 import logging
+import traceback
 
 from bq3d.utils.chunking import unique_slice
 from bq3d.utils.files import unique_temp_dir
@@ -81,7 +82,23 @@ def processSubStack(flow, output_properties, source, overlap_indices, unique_ind
             for z in range(*zRng):
                 fname = h + (dfmt % z) + ext
                 if not os.path.isfile(fname):
-                    io.empty(fname, io.dataSize(source)[1:], filtered_im.dtype)
+                    n_tries = 5
+                    for tries in range(n_tries):   # in case this somehow fails - we can't afford long processes failing near its end. 
+                        try:
+                            io.empty(fname, io.dataSize(source)[1:], filtered_im.dtype)
+                            break
+                        except Exception as err:
+                        #except ValueError as err:
+                            #File "...python3.9/site-packages/numpy/core/memmap.py", line 267, in __new__
+                            # mm = mmap.mmap(fid.fileno(), bytes, access=acc, offset=start)
+                            # ValueError: mmap length is greater than file size
+                            
+                            # printing stack trace
+                            traceback.print_exc()
+                            log.error('Error creating ' + fname)
+                            log.error(err)
+                            # if tries==n_tries-1:
+                            #     raise
 
             unique = filtered_im[unique_slice(overlap_indices, unique_indices)]
             io.writeData(save, unique, substack=unique_indices)

--- a/common/parameter.py
+++ b/common/parameter.py
@@ -11,14 +11,16 @@ BaseDirectory = '/mnt/ssd/working-directory/analysis'
 DataDirectory = '/mnt/ssd/working-directory/data'
 
 #Data File and Reference channel File, usually as a sequence of files from the microscope
+#Regular expression is currently supported only in the '\d{}' style, for the filename part only. - see io.isFileExpression().
 SignalFile = os.path.join(DataDirectory, 'C01/lightsheet_data_Z\d{3,4}_C01.tif')
 AutofluoFile = os.path.join(DataDirectory, 'C02/lightsheet_data_Z\d{3,4}_C02.tif')
 
 #Resolution of the Raw Data (in um / pixel)
 OriginalResolution = (9, 9, 9);
 
-#Orientation: 1,2,3 means the same orientation as the reference and atlas files.
-#Flip axis with - sign (eg. (-1,2,3) flips z). 3D Rotate by swapping numbers. (eg. (2,1,3) swaps x and y)
+#Orientation: which axes from the input volume map to the output results' ZYXs.
+# 1,2,3 means the same orientation as the reference and atlas files.
+#Flip axis with - sign (eg. (-1,2,3) flips z). 3D Rotate by swapping numbers. (eg. (2,1,3) swaps z and y)
 FinalOrientation = (-1, 2, -3);
 
 #Resolution of the Atlas (in um/ pixel)


### PR DESCRIPTION
Fix wrong invert_orientation() .
Fix wrong image array indexing in readDataFiles().
Fix file system error due to renaming unclosed file.
Fix errors when original input are non-memmapable tiffs or has non-native byte order.
Various improvements on logging messages and filesystem error tolerance; documentation text fixes.